### PR TITLE
Multiple audio video support (part 3)

### DIFF
--- a/pypopquiz/io.py
+++ b/pypopquiz/io.py
@@ -86,8 +86,7 @@ def verify_input(input_data: Dict) -> None:
                                 "additionalProperties": True,
                                 "properties": {
                                     "source": {"type": "number"},
-                                    "interval": {"type": "array"},
-                                    "repetitions": {"type": "number"},
+                                    "interval": {"type": "array"}
                                 }
                             }
                         },
@@ -101,11 +100,11 @@ def verify_input(input_data: Dict) -> None:
                                 "additionalProperties": True,
                                 "properties": {
                                     "source": {"type": "number"},
-                                    "interval": {"type": "array"},
-                                    "repetitions": {"type": "number"},
+                                    "interval": {"type": "array"}
                                 }
                             }
                         },
+                        "repetitions": {"type": "number"},
                         "answer_video": {
                             "type": "array",
                             "minItems": 1,
@@ -116,8 +115,7 @@ def verify_input(input_data: Dict) -> None:
                                 "additionalProperties": True,
                                 "properties": {
                                     "source": {"type": "number"},
-                                    "interval": {"type": "array"},
-                                    "repetitions": {"type": "number"},
+                                    "interval": {"type": "array"}
                                 }
                             }
                         },
@@ -131,8 +129,7 @@ def verify_input(input_data: Dict) -> None:
                                 "additionalProperties": True,
                                 "properties": {
                                     "source": {"type": "number"},
-                                    "interval": {"type": "array"},
-                                    "repetitions": {"type": "number"},
+                                    "interval": {"type": "array"}
                                 }
                             }
                         },

--- a/pypopquiz/popquiz.py
+++ b/pypopquiz/popquiz.py
@@ -23,6 +23,7 @@ def popquiz(input_file: Path, output_dir: Path, backend: str) -> None:
 
     input_data = ppq.io.read_input(input_file)
     round_id = input_data["round"]
+    questioned = input_data["questioned"]
     ppq.io.log("Processing popquiz round {:d}".format(round_id))
 
     spacer_txt = input_data.get('spacers', '')
@@ -38,11 +39,16 @@ def popquiz(input_file: Path, output_dir: Path, backend: str) -> None:
         question_id = index + int(not first_question_is_example)  # start with 0 when having an example
         is_example = first_question_is_example and index == 0
 
-        ppq.io.log("Processing question {:d}".format(question_id))
-        q_video = ppq.video.create_video("question", round_id, question, question_id, output_dir,
+        answer_texts = []
+        for answers in question["answers"]:
+            answer_texts.append(" - ".join([answers[question_text]
+                                            for question_text in questioned if question_text in answers]))
+
+        ppq.io.log("Processing question {:d} {:s}".format(question_id, answer_texts))
+        q_video = ppq.video.create_video("question", round_id, question, question_id, output_dir, answer_texts,
                                          backend=backend, spacer_txt=spacer_txt,
                                          use_cached_video_files=use_cached_video_files, is_example=is_example)
-        a_video = ppq.video.create_video("answer", round_id, question, question_id, output_dir,
+        a_video = ppq.video.create_video("answer", round_id, question, question_id, output_dir, answer_texts,
                                          backend=backend, spacer_txt=spacer_txt,
                                          use_cached_video_files=use_cached_video_files, is_example=is_example)
         q_videos.append(q_video)

--- a/pypopquiz/popquiz.py
+++ b/pypopquiz/popquiz.py
@@ -44,7 +44,7 @@ def popquiz(input_file: Path, output_dir: Path, backend: str) -> None:
             answer_texts.append(" - ".join([answers[question_text]
                                             for question_text in questioned if question_text in answers]))
 
-        ppq.io.log("Processing question {:d} {:s}".format(question_id, answer_texts))
+        ppq.io.log("Processing question {:d} {:s}".format(question_id, str(answer_texts)))
         q_video = ppq.video.create_video("question", round_id, question, question_id, output_dir, answer_texts,
                                          backend=backend, spacer_txt=spacer_txt,
                                          use_cached_video_files=use_cached_video_files, is_example=is_example)

--- a/pypopquiz/video.py
+++ b/pypopquiz/video.py
@@ -30,15 +30,18 @@ def get_interval_length(interval: Tuple[int, int]) -> int:
     return interval[1] - interval[0]
 
 
-def filter_stream_video(stream: VideoBackend, interval: Tuple[int, int], fade_amount_s: int = 3) -> VideoBackend:
+def filter_stream_video(stream: VideoBackend, kind: str, interval: Tuple[int, int], answer_text: str,
+                        box_height: int = 100, fade_amount_s: int = 3) -> VideoBackend:
     """Adds ffmpeg filters to the stream, processing a single video stream"""
     stream.trim(start_s=interval[0], end_s=interval[1])
     stream.fade_in_and_out(fade_amount_s, get_interval_length(interval))
     stream.scale_video()
+    if kind == "answer":
+        stream.draw_text_in_box(answer_text, get_interval_length(interval), box_height, move=False, top=True)
     return stream
 
 
-def filter_stream_videos(stream: VideoBackend, kind: str, round_id: int, answer_text: str, question_id: int,
+def filter_stream_videos(stream: VideoBackend, kind: str, round_id: int, question_id: int,
                          repetitions: int, total_duration: int, box_height: int = 100,
                          spacer_txt: str = "", is_example: bool = False) -> VideoBackend:
     """Adds ffmpeg filters to the stream, processing the combined video stream"""
@@ -50,8 +53,6 @@ def filter_stream_videos(stream: VideoBackend, kind: str, round_id: int, answer_
         question_text += " ({:d}x)".format(repetitions)
 
     stream.draw_text_in_box(question_text, total_duration, box_height, move=True, top=False)
-    if kind == "answer":
-        stream.draw_text_in_box(answer_text, total_duration, box_height, move=False, top=True)
     repeat_stream(stream, repetitions)
     if spacer_txt != "" and kind == "question":
         stream.add_spacer(spacer_txt, duration_s=2)
@@ -94,7 +95,7 @@ def get_sources(question: Dict, media: str, kind: str) -> List[Dict]:
     return [sources[source_index] for source_index in source_indices]
 
 
-def create_video(kind: str, round_id: int, question: Dict, question_id: int, output_dir: Path,
+def create_video(kind: str, round_id: int, question: Dict, question_id: int, output_dir: Path, answer_texts: List[str],
                  width: int = 1280, height: int = 720, backend: str = 'ffmpeg', spacer_txt: str = "",
                  use_cached_video_files: bool = False, is_example: bool = False) -> Path:
     """Creates a video for one question, either a question or an answer video"""
@@ -126,21 +127,20 @@ def create_video(kind: str, round_id: int, question: Dict, question_id: int, out
 
     # Process the video(s)
     stream_videos = None
-    answer_text = " - ".join(question["answers"][0].values())  # TODO: Support multiple answer texts
     total_duration = 0
     for video_id, video_info in enumerate(question[kind+"_video"]):
         ppq.io.log("Processing video input {:d}/{:d}".format(video_id + 1, len(question[kind+"_video"])))
         interval = ppq.io.get_interval_in_s(video_info["interval"])
         total_duration += get_interval_length(interval)
         stream_video = backend_cls(video_files[video_id], has_video=True, has_audio=False, width=width, height=height)
-        stream_video = filter_stream_video(stream_video, interval)
+        stream_video = filter_stream_video(stream_video, kind, interval, answer_texts[video_id])
         if stream_videos is None:
             stream_videos = stream_video
         else:
             stream_videos.combine(stream_video)
     ppq.io.log("Processing final video")
     assert stream_videos is not None
-    stream_videos = filter_stream_videos(stream_videos, kind, round_id, answer_text, question_id, repetitions,
+    stream_videos = filter_stream_videos(stream_videos, kind, round_id, question_id, repetitions,
                                          total_duration, spacer_txt=spacer_txt, is_example=is_example)
 
     # Process the audio(s)

--- a/samples/round01.json
+++ b/samples/round01.json
@@ -2,26 +2,28 @@
   "round": 1,
   "theme": "Intro's",
   "questioned": ["artist", "title"],
-  "use_cached_video_files": true,
+  "use_cached_video_files": false,
   "questions": [
     {
       "sources": [
         {"source": "youtube", "identifier": "v2AC41dglnM", "format": "mp4"}
       ],
-      "question_video": [{"source": 0, "interval": ["0:00", "0:10"], "repetitions": 1}],
-      "question_audio": [{"source": 0, "interval": ["0:00", "0:10"], "repetitions": 1}],
-      "answer_video": [{"source": 0, "interval": ["2:40", "2:56"], "repetitions": 1}],
-      "answer_audio": [{"source": 0, "interval": ["2:40", "2:56"], "repetitions": 1}],
+      "question_video": [{"source": 0, "interval": ["0:00", "0:10"]}],
+      "question_audio": [{"source": 0, "interval": ["0:00", "0:10"]}],
+      "repetitions": 1,
+      "answer_video": [{"source": 0, "interval": ["2:40", "2:56"]}],
+      "answer_audio": [{"source": 0, "interval": ["2:40", "2:56"]}],
       "answers": [{"artist": "AC/DC", "title": "Thunderstruck"}]
     },
     {
       "sources": [
         {"source": "youtube", "identifier": "8mGBaXPlri8", "format": "mp4"}
       ],
-      "question_video": [{"source": 0, "interval": ["0:14", "0:22"], "repetitions": 1}],
-      "question_audio": [{"source": 0, "interval": ["0:14", "0:22"], "repetitions": 1}],
-      "answer_video": [{"source": 0, "interval": ["1:08", "1:27"], "repetitions": 1}],
-      "answer_audio": [{"source": 0, "interval": ["1:08", "1:27"], "repetitions": 1}],
+      "question_video": [{"source": 0, "interval": ["0:14", "0:22"]}],
+      "question_audio": [{"source": 0, "interval": ["0:14", "0:22"]}],
+      "repetitions": 1,
+      "answer_video": [{"source": 0, "interval": ["1:08", "1:27"]}],
+      "answer_audio": [{"source": 0, "interval": ["1:08", "1:27"]}],
       "answers": [{"artist": "All The Things She Said", "title": "t.A.T.u."}]
     }
   ]

--- a/samples/round02.json
+++ b/samples/round02.json
@@ -20,6 +20,21 @@
         {"artist clip": "The Wombats", "title clip": "Tokyo (Vampires & Wolves)"},
         {"artist song": "The Animals", "title song": "House of the Rising Sun"}
       ]
+    },
+    {
+      "sources": [
+        {"source": "youtube", "identifier": "QGJuMBdaqIw", "format": "mp4"},
+        {"source": "youtube", "identifier": "cuDDPF6vE6Y", "format": "mp4"}
+      ],
+      "question_video": [{"source": 0, "interval": ["0:46", "1:12"]}],
+      "question_audio": [{"source": 1, "interval": ["0:32", "0:58"]}],
+      "repetitions": 1,
+      "answer_video": [{"source": 0, "interval": ["1:15", "1:30"]}, {"source": 1, "interval": ["0:58", "1:18"]}],
+      "answer_audio": [{"source": 0, "interval": ["1:15", "1:30"]}, {"source": 1, "interval": ["0:58", "1:18"]}],
+      "answers": [
+        {"artist clip": "Katy Perry", "title clip": "Firework"},
+        {"artist song": "Enya", "title song": "Trains And Winter Rains"}
+      ]
     }
   ]
 }

--- a/samples/round02.json
+++ b/samples/round02.json
@@ -1,30 +1,21 @@
 {
   "round": 2,
-  "theme": "Advanced features demo",
-  "use_cached_video_files": true,
+  "theme": "Mixed audio & video",
   "background_image": "background.png",
   "questioned": ["artist clip", "title clip", "artist song", "title song"],
   "first_question_is_example": true,
+  "use_cached_video_files": false,
   "questions": [
     {
       "sources": [
         {"source": "youtube", "identifier": "DRhUIJextp8", "format": "mp4"},
         {"source": "youtube", "identifier": "PDKKeLhHgl8", "format": "mp4"}
       ],
-      "question_video": [
-        {"source": 0, "interval": ["1:21", "1:32"], "repetitions": 2}
-      ],
-      "question_audio": [
-        {"source": 1, "interval": ["0:45", "0:56"], "repetitions": 2}
-      ],
-      "answer_video": [
-        {"source": 0, "interval": ["1:37", "1:43"], "repetitions": 1},
-        {"source": 1, "interval": ["0:08", "0:20"], "repetitions": 1}
-      ],
-      "answer_audio": [
-        {"source": 0, "interval": ["1:37", "1:43"], "repetitions": 1},
-        {"source": 1, "interval": ["0:08", "0:20"], "repetitions": 1}
-      ],
+      "question_video": [{"source": 0, "interval": ["1:21", "1:32"]}],
+      "question_audio": [{"source": 1, "interval": ["0:45", "0:56"]}],
+      "repetitions": 2,
+      "answer_video": [{"source": 0, "interval": ["1:37", "1:43"]}, {"source": 1, "interval": ["0:08", "0:20"]}],
+      "answer_audio": [{"source": 0, "interval": ["1:37", "1:43"]}, {"source": 1, "interval": ["0:08", "0:20"]}],
       "answers": [
         {"artist clip": "The Wombats", "title clip": "Tokyo (Vampires & Wolves)"},
         {"artist song": "The Animals", "title song": "House of the Rising Sun"}


### PR DESCRIPTION
Two left over todo's:
* Made repetition count a per-question value: Repetition count now only applies to the question video, not to the answers. Repetition now adds a (2x) to the text in the video.
* Added support for multiple answer texts: Answers are now specific for an answer video. Per video they are presented as given in the 'questioned' order (list rather than dict)