### PR TITLE
Better display for more than two answers

### DIFF
--- a/pypopquiz/popquiz.py
+++ b/pypopquiz/popquiz.py
@@ -42,10 +42,9 @@ def popquiz(input_file: Path, output_dir: Path, backend: str) -> None:
 
         answer_texts = []
         for answers in question["answers"]:
-            answer_texts.append(" - ".join([answers[question_text]
-                                            for question_text in questioned if question_text in answers]))
+            answer_texts.append([answers[question_text] for question_text in questioned if question_text in answers])
 
-        ppq.io.log("Processing question {:d} {:s}".format(question_id, str(answer_texts)))
+        ppq.io.log("Processing question {:d}: {:s}".format(question_id, str(answer_texts)))
         q_video = ppq.video.create_video("question", round_id, question, question_id, output_dir, answer_texts,
                                          backend=backend, spacer_txt=spacer_txt,
                                          use_cached_video_files=use_cached_video_files, is_example=is_example)

--- a/samples/round04.json
+++ b/samples/round04.json
@@ -14,7 +14,7 @@
       "question_audio": [{"source": 0, "interval": ["0:19", "0:34"]}],
       "answer_video": [{"source": 0, "interval": ["0:15", "0:31"]}],
       "answer_audio": [{"source": 0, "interval": ["0:15", "0:31"]}],
-      "answers": [{"artist": "Nirvana", "title": "Lithium", "text": "(I'm so ugly)"}]
+      "answers": [{"artist": "Nirvana", "title": "Lithium", "text": "I'm so ugly"}]
     },
     {
       "sources": [
@@ -25,7 +25,7 @@
       "question_audio": [{"source": 0, "interval": ["1:07", "1:37"]}],
       "answer_video": [{"source": 0, "interval": ["1:02", "1:37"]}],
       "answer_audio": [{"source": 0, "interval": ["1:02", "1:37"]}],
-      "answers": [{"artist": "Celine Dion", "title": "My Heart Will Go On", "text": "(Wherever you are))"}]
+      "answers": [{"artist": "Celine Dion", "title": "My Heart Will Go On", "text": "Wherever you are"}]
     }
   ]
 }


### PR DESCRIPTION
Now only first and second answer are shown in the top box, the remainder is shown in the center. Note that for answers with more songs anyway more video's will be shown, so this only applies for more than 2 answers for a single song. Example is the missing-word round.