### PR TITLE
Single image as source

### DIFF
--- a/pypopquiz/backends/backend.py
+++ b/pypopquiz/backends/backend.py
@@ -68,6 +68,12 @@ class Backend(abc.ABC):
         """Creates a video of a certain duration with a black still image"""
         pass
 
+    @classmethod
+    def create_single_image_stream(cls, input_image: Path, duration: int,
+                                   width: int = 1280, height: int = 720) -> 'Backend':
+        """Creates a video of a certain duration with a single still image"""
+        pass
+
     def add_spacer(self, text: str, duration_s: float) -> None:
         """Add a text spacer to the start of the video clip."""
         pass

--- a/pypopquiz/backends/ffmpeg.py
+++ b/pypopquiz/backends/ffmpeg.py
@@ -136,7 +136,13 @@ class FFMpeg(ppq.backends.backend.Backend):
     def create_empty_stream(cls, duration: int, width: int = 1280, height: int = 720) -> 'FFMpeg':
         """Creates a video of a certain duration with a black still image"""
         still_image = pkg_resources.resource_filename("resources", "still_black.png")
-        stream = cls(Path(still_image), has_video=True, has_audio=False, width=width, height=height,
+        return cls.create_single_image_stream(Path(still_image), duration, width=width, height=height)
+
+    @classmethod
+    def create_single_image_stream(cls, input_image: Path, duration: int,
+                                   width: int = 1280, height: int = 720) -> 'FFMpeg':
+        """Creates a video of a certain duration with a single still image"""
+        stream = cls(input_image, has_video=True, has_audio=False, width=width, height=height,
                      t=duration, framerate=25, loop=1)
         stream.scale_video()
         return stream

--- a/pypopquiz/io.py
+++ b/pypopquiz/io.py
@@ -180,9 +180,13 @@ def verify_input(input_data: Dict) -> None:
             if source["source"] == "youtube":
                 if source_keys != {"format"}:
                     raise ValueError("Missing source keys from Youtube source {:s}".format(str(source)))
-            if source["source"] == "text":
+            elif source["source"] == "text":
                 if source_keys != {"text", "duration"}:
                     raise ValueError("Missing source keys from text source {:s}".format(str(source)))
+                source["format"] = "mp4"  # default format
+            elif source["source"] == "image":
+                if source_keys != {"duration"}:
+                    raise ValueError("Missing source keys from image source {:s}".format(str(source)))
                 source["format"] = "mp4"  # default format
         if len(question["answers"]) != len(question["answer_video"]):
             raise ValueError("Expected {:d} answers, got {:d}".

--- a/pypopquiz/sources.py
+++ b/pypopquiz/sources.py
@@ -36,5 +36,7 @@ def get_source(source_data: Dict[str, Any], output_dir: Path, input_dir: Path) -
         input_file.rename(output_dir / ppq.io.SOURCES_BASE_FOLDER)
     elif source_type == "text":
         ppq.video.create_text_video(output_file, source_data["text"], source_data["duration"])
+    elif source_type == "image":
+        ppq.video.create_video_from_single_image(output_file, source_data["identifier"], source_data["duration"])
     else:
         raise KeyError("Unsupported source(s) '{:s}'".format(source_type))

--- a/pypopquiz/video.py
+++ b/pypopquiz/video.py
@@ -205,3 +205,11 @@ def create_text_video(file_name: Path, source_texts: List[str], duration: int,
     for text_id, source_text in enumerate(source_texts):
         stream.draw_text(source_text, 0.5 - 0.1 * num_texts + 0.2 * text_id)
     stream.run(file_name)
+
+
+def create_video_from_single_image(file_name: Path, input_image: Path, duration: int,
+                                   width: int = 1280, height: int = 720, backend: str = 'ffmpeg') -> None:
+    """Generates a video with a specific background"""
+    backend_cls = get_backend(backend)
+    stream = backend_cls.create_single_image_stream(input_image, duration, width=width, height=height)
+    stream.run(file_name)

--- a/samples/round03.json
+++ b/samples/round03.json
@@ -6,24 +6,33 @@
   "use_cached_video_files": false,
   "questions": [
     {
-      "sources": [{"source": "youtube", "identifier": "9dcVOmEQzKA", "format": "mp4"}],
-      "question_video": [{"source": 0, "interval": ["1:06", "1:28"], "reverse": true}],
+      "sources": [
+        {"source": "youtube", "identifier": "9dcVOmEQzKA", "format": "mp4"},
+        {"source": "image", "identifier": "background.png", "duration": 22}
+      ],
+      "question_video": [{"source": 1}],
       "question_audio": [{"source": 0, "interval": ["1:06", "1:28"], "reverse": true}],
       "answer_video": [{"source": 0, "interval": ["1:06", "1:28"]}],
       "answer_audio": [{"source": 0, "interval": ["1:06", "1:28"]}],
       "answers": [{"artist": "Eminem", "title": "Just Lose It"}]
     },
     {
-      "sources": [{"source": "youtube", "identifier": "rn_YodiJO6k", "format": "mp4"}],
-      "question_video": [{"source": 0, "interval": ["1:59", "2:26"], "reverse": true}],
+      "sources": [
+        {"source": "youtube", "identifier": "rn_YodiJO6k", "format": "mp4"},
+        {"source": "image", "identifier": "background.png", "duration": 27}
+      ],
+      "question_video": [{"source": 1}],
       "question_audio": [{"source": 0, "interval": ["1:59", "2:26"], "reverse": true}],
       "answer_video": [{"source": 0, "interval": ["1:59", "2:26"]}],
       "answer_audio": [{"source": 0, "interval": ["1:59", "2:26"]}],
       "answers": [{"artist": "Red Hot Chili Peppers", "title": "Otherside"}]
     },
     {
-      "sources": [{"source": "youtube", "identifier": "SwYN7mTi6HM", "format": "mp4"}],
-      "question_video": [{"source": 0, "interval": ["1:12", "1:28"], "reverse": true}],
+      "sources": [
+        {"source": "youtube", "identifier": "SwYN7mTi6HM", "format": "mp4"},
+        {"source": "image", "identifier": "background.png", "duration": 16}
+      ],
+      "question_video": [{"source": 1}],
       "question_audio": [{"source": 0, "interval": ["1:12", "1:28"], "reverse": true}],
       "answer_video": [{"source": 0, "interval": ["1:12", "1:28"]}],
       "answer_audio": [{"source": 0, "interval": ["1:12", "1:28"]}],


### PR DESCRIPTION
I made it an option to use a single image (e.g. a PNG) as a video source. This will make it possible to create audio-only rounds, but will also make it possible to add a specific image (e.g. album cover or artist) per question if needed.

Making it possible to not specify anything in case we want a black background is not implemented yet, but in the FFMPEG use-case that will anyway have to be implemented with a still image as a source, so that implementation should be easy (just add a background "image" as as "source" if no video input is detected) after this is merged in.