### PR TITLE
Auto fill in unspecified video input

### DIFF
--- a/samples/round03.json
+++ b/samples/round03.json
@@ -18,10 +18,8 @@
     },
     {
       "sources": [
-        {"source": "youtube", "identifier": "rn_YodiJO6k", "format": "mp4"},
-        {"source": "image", "identifier": "background.png", "duration": 27}
+        {"source": "youtube", "identifier": "rn_YodiJO6k", "format": "mp4"}
       ],
-      "question_video": [{"source": 1}],
       "question_audio": [{"source": 0, "interval": ["1:59", "2:26"], "reverse": true}],
       "answer_video": [{"source": 0, "interval": ["1:59", "2:26"]}],
       "answer_audio": [{"source": 0, "interval": ["1:59", "2:26"]}],
@@ -29,10 +27,8 @@
     },
     {
       "sources": [
-        {"source": "youtube", "identifier": "SwYN7mTi6HM", "format": "mp4"},
-        {"source": "image", "identifier": "background.png", "duration": 16}
+        {"source": "youtube", "identifier": "SwYN7mTi6HM", "format": "mp4"}
       ],
-      "question_video": [{"source": 1}],
       "question_audio": [{"source": 0, "interval": ["1:12", "1:28"], "reverse": true}],
       "answer_video": [{"source": 0, "interval": ["1:12", "1:28"]}],
       "answer_audio": [{"source": 0, "interval": ["1:12", "1:28"]}],


### PR DESCRIPTION
As discussed, it is now possible to leave out the video items in the JSON and it will be automatically filled in with a new source that is a still image with a matching duration of the audio entry. Adjusted sample03 to show this, but still also show the other method of setting an image manually.