### PR TITLE
Width and height as command-line arguments

### DIFF
--- a/pypopquiz/backends/backend.py
+++ b/pypopquiz/backends/backend.py
@@ -20,6 +20,14 @@ class Backend(abc.ABC):
         self.width = width
         self.height = height
 
+    def get_font_size(self) -> int:
+        """Retrieves an appropriate font-size for this video"""
+        return self.height // 14
+
+    def get_box_height(self) -> int:
+        """Retrieves an appropriate box-height for this video"""
+        return self.height // 7
+
     @abc.abstractmethod
     def trim(self, start_s: int, end_s: int) -> None:
         """Trims a stream to a given start and end time measured in seconds"""
@@ -46,7 +54,7 @@ class Backend(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def draw_text_in_box(self, video_text: str, length: int, box_height: int, move: bool, top: bool) -> None:
+    def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool) -> None:
         """Draws a semi-transparent box either at the top or bottom and writes text in it, optionally scrolling by"""
         pass
 

--- a/pypopquiz/backends/backend.py
+++ b/pypopquiz/backends/backend.py
@@ -14,7 +14,7 @@ import pypopquiz.io
 class Backend(abc.ABC):
     """Abstract class to specify the backend interface"""
 
-    def __init__(self, has_video: bool, has_audio: bool, width: int = 1280, height: int = 720) -> None:
+    def __init__(self, has_video: bool, has_audio: bool, width: int, height: int) -> None:
         self.has_video = has_video
         self.has_audio = has_audio
         self.width = width
@@ -64,13 +64,13 @@ class Backend(abc.ABC):
         pass
 
     @classmethod
-    def create_empty_stream(cls, duration: int, width: int = 1280, height: int = 720) -> 'Backend':
+    def create_empty_stream(cls, duration: int, width: int, height: int) -> 'Backend':
         """Creates a video of a certain duration with a black still image"""
         pass
 
     @classmethod
     def create_single_image_stream(cls, input_image: Path, duration: int,
-                                   width: int = 1280, height: int = 720) -> 'Backend':
+                                   width: int, height: int) -> 'Backend':
         """Creates a video of a certain duration with a single still image"""
         pass
 

--- a/pypopquiz/backends/ffmpeg.py
+++ b/pypopquiz/backends/ffmpeg.py
@@ -16,7 +16,7 @@ class FFMpeg(ppq.backends.backend.Backend):
     """FFMPEG backend, implements interface from base-class"""
 
     def __init__(self, source_file: Path, has_video: bool, has_audio: bool,
-                 display_graph: bool = False, width: int = 1280, height: int = 720, **kwargs: Any) -> None:
+                 width: int, height: int, display_graph: bool = False, **kwargs: Any) -> None:
         super().__init__(has_video, has_audio, width, height)
         stream = ffmpeg.input(str(source_file), **kwargs)
         self.display_graph = display_graph
@@ -133,14 +133,14 @@ class FFMpeg(ppq.backends.backend.Backend):
         return file_name
 
     @classmethod
-    def create_empty_stream(cls, duration: int, width: int = 1280, height: int = 720) -> 'FFMpeg':
+    def create_empty_stream(cls, duration: int, width: int, height: int) -> 'FFMpeg':
         """Creates a video of a certain duration with a black still image"""
         still_image = pkg_resources.resource_filename("resources", "still_black.png")
         return cls.create_single_image_stream(Path(still_image), duration, width=width, height=height)
 
     @classmethod
     def create_single_image_stream(cls, input_image: Path, duration: int,
-                                   width: int = 1280, height: int = 720) -> 'FFMpeg':
+                                   width: int, height: int) -> 'FFMpeg':
         """Creates a video of a certain duration with a single still image"""
         stream = cls(input_image, has_video=True, has_audio=False, width=width, height=height,
                      t=duration, framerate=25, loop=1)

--- a/pypopquiz/backends/ffmpeg.py
+++ b/pypopquiz/backends/ffmpeg.py
@@ -72,12 +72,13 @@ class FFMpeg(ppq.backends.backend.Backend):
         stream_v = stream_v.filter("pad", width=width, height=height, x="(ow-iw)/2", y="(oh-ih)/2", color="black")
         self.stream_v = stream_v.filter("setsar", sar="1/1")
 
-    def draw_text_in_box(self, video_text: str, length: int, box_height: int, move: bool, top: bool) -> None:
+    def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool) -> None:
         """Draws a semi-transparent box either at the top or bottom and writes text in it, optionally scrolling by"""
         if not self.has_video:
             return
         width = self.width
         height = self.height
+        box_height = self.get_box_height()
         y_location = 0 if top else height - box_height
 
         thickness = "fill" if self.version.startswith("N") else "max"  # Assume nightlies are new.
@@ -85,7 +86,7 @@ class FFMpeg(ppq.backends.backend.Backend):
                                          thickness=thickness)
         x_location_text = "{:d} * t / {:d}".format(width, length) if move else "{:d} - text_w / 2".format(width // 2)
         y_location_text = int(box_height * 1 / 4) if top else int(height - box_height * 3 / 4)
-        self.stream_v = stream_v.drawtext(text=video_text, fontcolor="white", fontsize=50,
+        self.stream_v = stream_v.drawtext(text=video_text, fontcolor="white", fontsize=self.get_font_size(),
                                           x=x_location_text, y=y_location_text)
 
     def draw_text(self, video_text: str, height_fraction: float) -> None:
@@ -96,7 +97,7 @@ class FFMpeg(ppq.backends.backend.Backend):
 
         x_location_text = "{:d} - text_w / 2".format(self.width // 2)
         y_location_text = self.height * height_fraction
-        self.stream_v = self.stream_v.drawtext(text=video_text, fontcolor="white", fontsize=50,
+        self.stream_v = self.stream_v.drawtext(text=video_text, fontcolor="white", fontsize=self.get_font_size(),
                                                x=x_location_text, y=y_location_text)
 
     def add_audio(self, other: 'FFMpeg') -> None:  # type: ignore

--- a/pypopquiz/backends/moviepy.py
+++ b/pypopquiz/backends/moviepy.py
@@ -127,11 +127,11 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         assert self.has_video
         self.clip = self.clip.fx(vfx.resize, (self.width, self.height))  # TODO: padding with black
 
-    def draw_text_in_box(self, video_text: str, length: int, box_height: int, move: bool, top: bool) -> None:
+    def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool) -> None:
         """Draws a semi-transparent box either at the top or bottom and writes text in it, optionally scrolling by"""
         assert self.has_video
         self.clip = Moviepy.draw_text_in_box_on_video(
-            self.clip, video_text, length, self.width, self.height, box_height, move, top
+            self.clip, video_text, length, self.width, self.height, self.get_box_height(), move, top
         )
 
     @staticmethod
@@ -190,8 +190,8 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         assert self.has_video
         duration_s = 0  # Don't care
         self.clip = Moviepy.draw_text_in_box_on_video(
-            self.clip, text, duration_s, self.width, self.height, box_height=100, move=False, top=False,
-            on_box=False, center=True, interval=interval, fontsize=50
+            self.clip, text, duration_s, self.width, self.height, box_height=self.get_box_height(),
+            move=False, top=False, on_box=False, center=True, interval=interval, fontsize=self.get_font_size()
         )
 
     def add_spacer(self, text: str, duration_s: float) -> None:
@@ -201,7 +201,8 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         color = med.ColorClip(size=(self.width, self.height), color=(0, 0, 0), duration=duration_s)
         color = color.set_fps(30)  # pylint: disable=assignment-from-no-return
         spacer = Moviepy.draw_text_in_box_on_video(
-            color, text, duration_s, self.width, self.height, box_height=100, move=True, top=False, on_box=False
+            color, text, duration_s, self.width, self.height, box_height=self.get_box_height(),
+            move=True, top=False, on_box=False
         )
         self.clip = med.concatenate_videoclips([spacer, self.clip])
 

--- a/pypopquiz/backends/moviepy.py
+++ b/pypopquiz/backends/moviepy.py
@@ -60,7 +60,7 @@ class Moviepy(pypopquiz.backends.backend.Backend):
     """Moviepy backend."""
 
     def __init__(self, source_file: Path, has_video: bool, has_audio: bool,
-                 width: int = 1280, height: int = 720) -> None:
+                 width: int, height: int) -> None:
         super().__init__(has_video, has_audio, width, height)
         # Keep a reference to the original object that read input files.
         # moviepy leaks process references even if these objects go out of scope,

--- a/pypopquiz/popquiz.py
+++ b/pypopquiz/popquiz.py
@@ -16,10 +16,12 @@ def parse_arguments():
     parser.add_argument("-i", "--input_file", required=True, help="Input JSON file with popquiz info", type=Path)
     parser.add_argument("-o", "--output_dir", required=True, help="Output dir with popquiz data", type=Path)
     parser.add_argument("-b", "--backend", required=False, help="Backend selection", type=str, default='ffmpeg')
+    parser.add_argument("--width", required=False, help="Video width", type=int, default=1280)
+    parser.add_argument("--height", required=False, help="Video height", type=int, default=720)
     return vars(parser.parse_args())
 
 
-def popquiz(input_file: Path, output_dir: Path, backend: str) -> None:
+def popquiz(input_file: Path, output_dir: Path, backend: str, width: int, height: int) -> None:
     """The main routine, constructing the entire popquiz output"""
 
     input_data = ppq.io.read_input(input_file)
@@ -33,7 +35,7 @@ def popquiz(input_file: Path, output_dir: Path, backend: str) -> None:
 
     for question in input_data["questions"]:
         for source in question["sources"]:
-            ppq.sources.get_source(source, output_dir, input_file.parent)
+            ppq.sources.get_source(source, output_dir, input_file.parent, width=width, height=height)
 
     q_videos, a_videos = [], []
     for index, question in enumerate(input_data["questions"]):
@@ -46,10 +48,10 @@ def popquiz(input_file: Path, output_dir: Path, backend: str) -> None:
 
         ppq.io.log("Processing question {:d}: {:s}".format(question_id, str(answer_texts)))
         q_video = ppq.video.create_video("question", round_id, question, question_id, output_dir, answer_texts,
-                                         backend=backend, spacer_txt=spacer_txt,
+                                         width=width, height=height, backend=backend, spacer_txt=spacer_txt,
                                          use_cached_video_files=use_cached_video_files, is_example=is_example)
         a_video = ppq.video.create_video("answer", round_id, question, question_id, output_dir, answer_texts,
-                                         backend=backend, spacer_txt=spacer_txt,
+                                         width=width, height=height, backend=backend, spacer_txt=spacer_txt,
                                          use_cached_video_files=use_cached_video_files, is_example=is_example)
         q_videos.append(q_video)
         if is_example:
@@ -57,9 +59,9 @@ def popquiz(input_file: Path, output_dir: Path, backend: str) -> None:
         else:
             a_videos.append(a_video)
 
-    ppq.video.combine_videos(q_videos, "question", round_id, output_dir, backend=backend)
+    ppq.video.combine_videos(q_videos, "question", round_id, output_dir, backend=backend, width=width, height=height)
     if a_videos:
-        ppq.video.combine_videos(a_videos, "answer", round_id, output_dir, backend=backend)
+        ppq.video.combine_videos(a_videos, "answer", round_id, output_dir, backend=backend, width=width, height=height)
 
     ppq.sheets.create_sheets("question", input_data, output_dir)
     ppq.sheets.create_sheets("answer", input_data, output_dir)

--- a/pypopquiz/sources.py
+++ b/pypopquiz/sources.py
@@ -10,7 +10,7 @@ import pypopquiz.io
 import pypopquiz.video
 
 
-def get_source(source_data: Dict[str, Any], output_dir: Path, input_dir: Path) -> None:
+def get_source(source_data: Dict[str, Any], output_dir: Path, input_dir: Path, width: int, height: int) -> None:
     """Retrieves a source and stores is in a local output directory, skips if already there"""
 
     if not output_dir.exists():
@@ -35,8 +35,10 @@ def get_source(source_data: Dict[str, Any], output_dir: Path, input_dir: Path) -
         input_file = input_dir / ppq.io.get_source_file_name(source_data)
         input_file.rename(output_dir / ppq.io.SOURCES_BASE_FOLDER)
     elif source_type == "text":
-        ppq.video.create_text_video(output_file, source_data["text"], source_data["duration"])
+        ppq.video.create_text_video(output_file, source_data["text"], source_data["duration"],
+                                    width=width, height=height)
     elif source_type == "image":
-        ppq.video.create_video_from_single_image(output_file, source_data["identifier"], source_data["duration"])
+        ppq.video.create_video_from_single_image(output_file, source_data["identifier"], source_data["duration"],
+                                                 width=width, height=height)
     else:
         raise KeyError("Unsupported source(s) '{:s}'".format(source_type))

--- a/pypopquiz/video.py
+++ b/pypopquiz/video.py
@@ -118,8 +118,8 @@ def get_sources(question: Dict, media: str, kind: str) -> List[Dict]:
 
 
 def create_video(kind: str, round_id: int, question: Dict, question_id: int, output_dir: Path,
-                 answer_texts: List[List[str]],
-                 width: int = 1280, height: int = 720, backend: str = 'ffmpeg', spacer_txt: str = "",
+                 answer_texts: List[List[str]], width: int, height: int,
+                 backend: str = 'ffmpeg', spacer_txt: str = "",
                  use_cached_video_files: bool = False, is_example: bool = False) -> Path:
     """Creates a video for one question, either a question or an answer video"""
     # pylint: disable=too-many-locals,too-many-statements
@@ -196,15 +196,15 @@ def create_video(kind: str, round_id: int, question: Dict, question_id: int, out
     return file_name_out
 
 
-def combine_videos(video_files: List[Path], kind: str, round_id: int, output_dir: Path,
+def combine_videos(video_files: List[Path], kind: str, round_id: int, output_dir: Path, width: int, height: int,
                    backend: str = 'ffmpeg') -> None:
     """Combines a list of video files together into a single video"""
     backend_cls = get_backend(backend)
 
     assert video_files  # assumes at least one item
-    stream = backend_cls(video_files[0], has_video=True, has_audio=True)
+    stream = backend_cls(video_files[0], has_video=True, has_audio=True, width=width, height=height)
     for video_file in video_files[1:]:
-        new_stream = backend_cls(video_file, has_video=True, has_audio=True)
+        new_stream = backend_cls(video_file, has_video=True, has_audio=True, width=width, height=height)
         stream.combine(new_stream)
 
     file_name = output_dir / ("{:02d}_{:s}{:s}".format(round_id, kind, video_files[0].suffix))
@@ -212,7 +212,7 @@ def combine_videos(video_files: List[Path], kind: str, round_id: int, output_dir
 
 
 def create_text_video(file_name: Path, source_texts: List[str], duration: int,
-                      width: int = 1280, height: int = 720, backend: str = 'ffmpeg') -> None:
+                      width: int, height: int, backend: str = 'ffmpeg') -> None:
     """Generates a video with text on a black background"""
     backend_cls = get_backend(backend)
     stream = backend_cls.create_empty_stream(duration, width=width, height=height)
@@ -223,7 +223,7 @@ def create_text_video(file_name: Path, source_texts: List[str], duration: int,
 
 
 def create_video_from_single_image(file_name: Path, input_image: Path, duration: int,
-                                   width: int = 1280, height: int = 720, backend: str = 'ffmpeg') -> None:
+                                   width: int, height: int, backend: str = 'ffmpeg') -> None:
     """Generates a video with a specific background"""
     backend_cls = get_backend(backend)
     stream = backend_cls.create_single_image_stream(input_image, duration, width=width, height=height)

--- a/pypopquiz/video.py
+++ b/pypopquiz/video.py
@@ -31,7 +31,7 @@ def get_interval_length(interval: Tuple[int, int]) -> int:
 
 
 def filter_stream_video(stream: VideoBackend, kind: str, interval: Tuple[int, int], answer_texts: List[str],
-                        reverse: bool, box_height: int = 100, fade_amount_s: int = 3,
+                        reverse: bool, fade_amount_s: int = 3,
                         answer_label_events: Optional[List] = None) -> VideoBackend:
     """Adds ffmpeg filters to the stream, processing a single video stream"""
     if kind == "answer" and answer_label_events is not None:
@@ -48,7 +48,7 @@ def filter_stream_video(stream: VideoBackend, kind: str, interval: Tuple[int, in
     if kind == "answer":
         # (up to the) first two answers are joined together with " - " and shown at the top
         answer_text = " - ".join(answer_texts[:2])
-        stream.draw_text_in_box(answer_text, get_interval_length(interval), box_height, move=False, top=True)
+        stream.draw_text_in_box(answer_text, get_interval_length(interval), move=False, top=True)
         # Remainder is shown in the center of the video
         for text_id, answer_text in enumerate(answer_texts[2:]):
             stream.draw_text(answer_text, 0.5 - 0.1 * len(answer_texts[2:]) + 0.2 * text_id)
@@ -56,7 +56,7 @@ def filter_stream_video(stream: VideoBackend, kind: str, interval: Tuple[int, in
 
 
 def filter_stream_videos(stream: VideoBackend, kind: str, round_id: int, question_id: int,
-                         repetitions: int, total_duration: int, box_height: int = 100,
+                         repetitions: int, total_duration: int,
                          spacer_txt: str = "", is_example: bool = False) -> VideoBackend:
     """Adds ffmpeg filters to the stream, processing the combined video stream"""
     if is_example:
@@ -66,7 +66,7 @@ def filter_stream_videos(stream: VideoBackend, kind: str, round_id: int, questio
     if repetitions > 1:
         question_text += " ({:d}x)".format(repetitions)
 
-    stream.draw_text_in_box(question_text, total_duration, box_height, move=True, top=False)
+    stream.draw_text_in_box(question_text, total_duration, move=True, top=False)
     repeat_stream(stream, repetitions)
     if spacer_txt != "" and kind == "question":
         stream.add_spacer(spacer_txt, duration_s=2)


### PR DESCRIPTION
The width and height are now not specified anymore anywhere in the code, they are now command-line arguments with defaults to 720x1280. Settings them smaller speeds up rendering a great deal and can be quite useful for developers but also for designers of quiz rounds. Example in lower resolution:
```
popquiz.py -i samples/round02.json -o data_dir --height 180 --width 320
```