### PR TITLE
Added aspect-ratio preserving scaling to moviepy.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -484,7 +484,7 @@ max-locals=28
 max-parents=7
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=25
 
 # Maximum number of return / yield for function / method body.
 max-returns=6

--- a/test/test_moviepy.py
+++ b/test/test_moviepy.py
@@ -1,0 +1,15 @@
+# pylint: disable=missing-docstring
+import unittest
+
+import pypopquiz as ppq
+import pypopquiz.backends.moviepy
+
+class TestMoviepy(unittest.TestCase):
+    def test_get_scaled_size(self) -> None:
+        mpy = ppq.backends.moviepy.Moviepy
+        self.assertEqual(mpy.get_scaled_size(800, 600, 400, 300), (400, 300))
+        self.assertEqual(mpy.get_scaled_size(800, 600, 1200, 300), (400, 300))
+        self.assertEqual(mpy.get_scaled_size(800, 600, 800, 1200), (800, 600))
+        self.assertEqual(mpy.get_scaled_size(800, 600, 800, 300), (400, 300))
+        self.assertEqual(mpy.get_scaled_size(400, 300, 800, 700), (800, 600))
+        self.assertEqual(mpy.get_scaled_size(800, 600, 200, 75), (100, 75))


### PR DESCRIPTION
Scaling now preserves aspect ratio of input video, i.e. black-bar support.