### PR TITLE
Added feature to delay the answer text appearance by 3 seconds

### DIFF
--- a/pypopquiz/backends/backend.py
+++ b/pypopquiz/backends/backend.py
@@ -5,7 +5,7 @@ import contextlib
 from pathlib import Path
 import shutil
 import tempfile
-from typing import Generator, Tuple
+from typing import Generator, Tuple, Optional
 
 import pypopquiz as ppq
 import pypopquiz.io
@@ -54,7 +54,8 @@ class Backend(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool) -> None:
+    def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool,
+                         delay_in_sec: Optional[int] = None) -> None:
         """Draws a semi-transparent box either at the top or bottom and writes text in it, optionally scrolling by"""
         pass
 

--- a/pypopquiz/backends/ffmpeg.py
+++ b/pypopquiz/backends/ffmpeg.py
@@ -2,7 +2,7 @@
 
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import pkg_resources
 import ffmpeg
@@ -76,7 +76,8 @@ class FFMpeg(ppq.backends.backend.Backend):
         stream_v = stream_v.filter("pad", width=width, height=height, x="(ow-iw)/2", y="(oh-ih)/2", color="black")
         self.stream_v = stream_v.filter("setsar", sar="1/1")
 
-    def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool) -> None:
+    def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool,
+                         delay_in_sec: Optional[int] = None) -> None:
         """Draws a semi-transparent box either at the top or bottom and writes text in it, optionally scrolling by"""
         if not self.has_video:
             return
@@ -90,6 +91,8 @@ class FFMpeg(ppq.backends.backend.Backend):
                                          thickness=thickness)
         x_location_text = "{:d} * t / {:d}".format(width, length) if move else "{:d} - text_w / 2".format(width // 2)
         y_location_text = int(box_height * 1 / 4) if top else int(height - box_height * 3 / 4)
+        if delay_in_sec is not None:
+            y_location_text = "{:d} - lt(t, {:d}) * 1000".format(y_location_text, delay_in_sec)
         self.stream_v = stream_v.drawtext(text=video_text, fontcolor="white", fontsize=self.get_font_size(),
                                           x=x_location_text, y=y_location_text)
 

--- a/pypopquiz/backends/ffmpeg.py
+++ b/pypopquiz/backends/ffmpeg.py
@@ -90,9 +90,9 @@ class FFMpeg(ppq.backends.backend.Backend):
         stream_v = self.stream_v.drawbox(x=0, y=y_location, width=width, height=box_height, color="gray@0.5",
                                          thickness=thickness)
         x_location_text = "{:d} * t / {:d}".format(width, length) if move else "{:d} - text_w / 2".format(width // 2)
-        y_location_text = int(box_height * 1 / 4) if top else int(height - box_height * 3 / 4)
+        y_location_text = str(int(box_height * 1 / 4)) if top else str(int(height - box_height * 3 / 4))
         if delay_in_sec is not None:
-            y_location_text = "{:d} - lt(t, {:d}) * 1000".format(y_location_text, delay_in_sec)
+            y_location_text = "{:s} - lt(t, {:d}) * 1000".format(y_location_text, delay_in_sec)
         self.stream_v = stream_v.drawtext(text=video_text, fontcolor="white", fontsize=self.get_font_size(),
                                           x=x_location_text, y=y_location_text)
 

--- a/pypopquiz/backends/moviepy.py
+++ b/pypopquiz/backends/moviepy.py
@@ -187,7 +187,8 @@ class Moviepy(pypopquiz.backends.backend.Backend):
             interval=interval, fontsize=self.get_font_size()
         )
 
-    def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool) -> None:
+    def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool,
+                         delay_in_sec: Optional[int] = None) -> None:
         """Draws a semi-transparent box either at the top or bottom and writes text in it, optionally scrolling by"""
         assert self.has_video
         self.clip = Moviepy.draw_text_in_box_on_video(

--- a/pypopquiz/video.py
+++ b/pypopquiz/video.py
@@ -31,7 +31,7 @@ def get_interval_length(interval: Tuple[int, int]) -> int:
 
 
 def filter_stream_video(stream: VideoBackend, kind: str, interval: Tuple[int, int], answer_texts: List[str],
-                        reverse: bool, fade_amount_s: int = 3,
+                        reverse: bool, fade_amount_s: int = 3, delay_answer_text_s: int = 3,
                         answer_label_events: Optional[List] = None) -> VideoBackend:
     """Adds ffmpeg filters to the stream, processing a single video stream"""
     if kind == "answer" and answer_label_events is not None:
@@ -48,7 +48,8 @@ def filter_stream_video(stream: VideoBackend, kind: str, interval: Tuple[int, in
     if kind == "answer":
         # (up to the) first two answers are joined together with " - " and shown at the top
         answer_text = " - ".join(answer_texts[:2])
-        stream.draw_text_in_box(answer_text, get_interval_length(interval), move=False, top=True)
+        stream.draw_text_in_box(answer_text, get_interval_length(interval), move=False, top=True,
+                                delay_in_sec=delay_answer_text_s)
         # Remainder is shown in the center of the video
         for text_id, answer_text in enumerate(answer_texts[2:]):
             stream.draw_text(answer_text, 0.5 - 0.1 * len(answer_texts[2:]) + 0.2 * text_id)


### PR DESCRIPTION
It's been a while, but here is one of the features I still wanted to have: delaying the answer text from appearing by a few seconds. This way there it is more exciting because you first hear/see the answer audio/video, and then later the actual answer.

Does require an implementation the other back-end as well.