### PR TITLE
Crossfade feature, image clips, auto interval inference 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
 
 install:
+  - sudo apt-get update
   - sudo apt-get install ffmpeg
   - pip install mypy pylint
   - pylint --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 cache: pip
 python:
@@ -7,7 +7,7 @@ python:
 
 install:
   - sudo apt-get update
-  - sudo apt-get install ffmpeg
+  - sudo apt-get install -y ffmpeg
   - pip install mypy pylint
   - pylint --version
   - mypy --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
 
 install:
+  - apt install ffmpeg
   - pip install mypy pylint
   - pylint --version
   - mypy --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ python:
   - "3.5"
   - "3.6"
 
+addons:
+  apt:
+    packages:
+    - ffmpeg
+
 install:
-  - sudo apt-get update
-  - sudo apt-get install -y ffmpeg
   - pip install mypy pylint
   - pylint --version
   - mypy --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.6"
 
 install:
-  - apt install ffmpeg
+  - sudo apt-get install ffmpeg
   - pip install mypy pylint
   - pylint --version
   - mypy --version

--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Requirements
 Tested on Linux and Windows. Requires Python 3.5 or newer. Requires ffmpeg and the Python packages `pytube` and `ffmpeg-python` or `moviepy`, installed as part of the requirements.
 
 Moviepy
-+++++++
+_______
 
 On Windows: Set environment variables pointing to ffmpeg and imagemagick (convert) for moviepy to use:
 
 `FFMPEG_BINARY=path_to_ffmpeg\ffmpeg.exe`
+
 `IMAGEMAGICK_BINARY=path_to_imagemagick\convert.exe`
 
 [Patch for no audio issue](https://github.com/Sv3n/moviepy/commit/130160de539bbdb0473bb2e994ed56a58f9f9ab0)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-PyPopQuiz: A Python/ffmpeg-based popquiz creator
-================
+# PyPopQuiz: A Python/ffmpeg-based popquiz creator
 
 [![Build Status](https://travis-ci.org/CNugteren/pypopquiz.svg?branch=master)](https://travis-ci.org/CNugteren/pypopquiz/branches)
 
@@ -9,13 +8,11 @@ PyPopQuiz is still under development, head back soon if you are looking for a fu
 
 To use the moviepy backend, add `-b moviepy` to the command line.
 
-Requirements
--------------
+## Requirements
 
 Tested on Linux and Windows. Requires Python 3.5 or newer. Requires ffmpeg and the Python packages `pytube` and `ffmpeg-python` or `moviepy`, installed as part of the requirements.
 
-Moviepy
-_______
+### Moviepy
 
 On Windows: Set environment variables pointing to ffmpeg and imagemagick (convert) for moviepy to use:
 
@@ -25,8 +22,7 @@ On Windows: Set environment variables pointing to ffmpeg and imagemagick (conver
 
 [Patch for no audio issue](https://github.com/Sv3n/moviepy/commit/130160de539bbdb0473bb2e994ed56a58f9f9ab0)
 
-Tests
--------------
+## Tests
 
 The tests are currently still quite limited, but you can already run the linters and/or unittests, e.g. from the root:
 
@@ -35,8 +31,7 @@ The tests are currently still quite limited, but you can already run the linters
     python -m unittest discover test
 
 
-Feature list / roadmap
--------------
+## Feature list / roadmap
 
 | Input/output                     | Status      |
 |----------------------------------|-------------|

--- a/README.md
+++ b/README.md
@@ -12,8 +12,17 @@ To use the moviepy backend, add `-b moviepy` to the command line.
 Requirements
 -------------
 
-Tested on Linux. Requires Python 3.5 or newer. Requires ffmpeg and the Python packages `pytube` and `ffmpeg-python` or `moviepy`, installed as part of the requirements.
+Tested on Linux and Windows. Requires Python 3.5 or newer. Requires ffmpeg and the Python packages `pytube` and `ffmpeg-python` or `moviepy`, installed as part of the requirements.
 
+Moviepy
++++++++
+
+On Windows: Set environment variables pointing to ffmpeg and imagemagick (convert) for moviepy to use:
+
+`FFMPEG_BINARY=path_to_ffmpeg\ffmpeg.exe`
+`IMAGEMAGICK_BINARY=path_to_imagemagick\convert.exe`
+
+[Patch for no audio issue](https://github.com/Sv3n/moviepy/commit/130160de539bbdb0473bb2e994ed56a58f9f9ab0)
 
 Tests
 -------------

--- a/pypopquiz/backends/backend.py
+++ b/pypopquiz/backends/backend.py
@@ -55,7 +55,8 @@ class Backend(abc.ABC):
                          delay_in_sec: Optional[int] = None) -> None:
         """Draws a semi-transparent box either at the top or bottom and writes text in it, optionally scrolling by"""
 
-    def draw_text(self, video_text: str, height_fraction: float) -> None:
+    def draw_text(self, video_text: str, height_fraction: float,
+                  interval: Optional[Tuple[float, float]] = None) -> None:
         """Draws text in the center of the video at a certain height fraction"""
 
     @abc.abstractmethod
@@ -93,9 +94,6 @@ class Backend(abc.ABC):
 
     def replace_audio_by_beep(self, interval: Tuple[float, float], freq_hz: int = 1500) -> None:
         """Replace the original audio by a beep in a particular interval."""
-
-    def overlay_fading_text(self, text: str, interval: Tuple[float, float]):
-        """Overlay fading text on the clip."""
 
     @staticmethod
     @contextlib.contextmanager

--- a/pypopquiz/backends/backend.py
+++ b/pypopquiz/backends/backend.py
@@ -39,7 +39,8 @@ class Backend(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def combine(self, other: 'Backend', other_first: bool) -> None:
+    def combine(self, other: 'Backend', other_first: bool,
+                crossfade_duration: float = 0) -> None:
         """Combines this stream with another stream"""
         pass
 

--- a/pypopquiz/backends/backend.py
+++ b/pypopquiz/backends/backend.py
@@ -31,39 +31,32 @@ class Backend(abc.ABC):
     @abc.abstractmethod
     def trim(self, start_s: int, end_s: int) -> None:
         """Trims a stream to a given start and end time measured in seconds"""
-        pass
 
     @abc.abstractmethod
     def repeat(self) -> None:
         """Concatenates streams with itself to make a twice as long stream"""
-        pass
 
     @abc.abstractmethod
     def combine(self, other: 'Backend', other_first: bool,
                 crossfade_duration: float = 0) -> None:
         """Combines this stream with another stream"""
-        pass
 
     @abc.abstractmethod
     def fade_in_and_out(self, duration_s: int, video_length_s: int, fade_in: bool = True,
                         fade_out: bool = True) -> None:
         """Adds a fade-in and fade-out to/from black for the audio and video stream"""
-        pass
 
     @abc.abstractmethod
     def scale_video(self) -> None:
         """Scales the video and pads if necessary to the requested dimensions"""
-        pass
 
     @abc.abstractmethod
     def draw_text_in_box(self, video_text: str, length: int, move: bool, top: bool,
                          delay_in_sec: Optional[int] = None) -> None:
         """Draws a semi-transparent box either at the top or bottom and writes text in it, optionally scrolling by"""
-        pass
 
     def draw_text(self, video_text: str, height_fraction: float) -> None:
         """Draws text in the center of the video at a certain height fraction"""
-        pass
 
     @abc.abstractmethod
     def add_audio(self, other: 'Backend') -> None:  # type: ignore
@@ -72,46 +65,37 @@ class Backend(abc.ABC):
     @abc.abstractmethod
     def run(self, file_name: Path, dry_run: bool = False) -> Path:
         """Runs the backend to create the video, applying all the filters"""
-        pass
 
     @classmethod
     def create_empty_stream(cls, duration: int, width: int, height: int) -> 'Backend':
         """Creates a video of a certain duration with a black still image"""
-        pass
 
     @classmethod
     def create_silent_stream(cls, duration: float, width: int, height: int) -> 'Backend':
         """Creates audio of a certain duration with no sound"""
-        pass
 
     @classmethod
     def create_single_image_stream(cls, input_image: Path, duration: int,
                                    width: int, height: int) -> 'Backend':
         """Creates a video of a certain duration with a single still image"""
-        pass
 
     @abc.abstractmethod
     def add_spacer(self, text: str, duration_s: float) -> None:
         """Add a text spacer to the start of the video clip."""
-        pass
 
     @abc.abstractmethod
     def add_silence(self, duration_s: float) -> None:
         """Add a silence of a certain duration the an audio clip."""
-        pass
 
     @abc.abstractmethod
     def reverse(self) -> None:
         """Reverses an entire audio or video clip."""
-        pass
 
     def replace_audio_by_beep(self, interval: Tuple[float, float], freq_hz: int = 1500) -> None:
         """Replace the original audio by a beep in a particular interval."""
-        pass
 
     def overlay_fading_text(self, text: str, interval: Tuple[float, float]):
         """Overlay fading text on the clip."""
-        pass
 
     @staticmethod
     @contextlib.contextmanager

--- a/pypopquiz/backends/backend.py
+++ b/pypopquiz/backends/backend.py
@@ -45,7 +45,8 @@ class Backend(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def fade_in_and_out(self, duration_s: int, video_length_s: int) -> None:
+    def fade_in_and_out(self, duration_s: int, video_length_s: int, fade_in: bool = True,
+                        fade_out: bool = True) -> None:
         """Adds a fade-in and fade-out to/from black for the audio and video stream"""
         pass
 

--- a/pypopquiz/backends/ffmpeg.py
+++ b/pypopquiz/backends/ffmpeg.py
@@ -42,7 +42,8 @@ class FFMpeg(ppq.backends.backend.Backend):
             joined = ffmpeg.concat(stream_a[0].filter("afifo"), stream_a[1].filter("afifo"), v=0, a=1).node
             self.stream_a = joined[0]
 
-    def combine(self, other: 'FFMpeg', other_first: bool = False) -> None:  # type: ignore
+    def combine(self, other: 'FFMpeg', other_first: bool = False,  # type: ignore
+                crossfade_duration: float = 0) -> None:
         """Combines this stream with another stream"""
         first_stream = other if other_first else self
         second_stream = self if other_first else other

--- a/pypopquiz/backends/ffmpeg.py
+++ b/pypopquiz/backends/ffmpeg.py
@@ -2,7 +2,7 @@
 
 import subprocess
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 import pkg_resources
 import ffmpeg
@@ -102,7 +102,8 @@ class FFMpeg(ppq.backends.backend.Backend):
         self.stream_v = stream_v.drawtext(text=video_text, fontcolor="white", fontsize=self.get_font_size(),
                                           x=x_location_text, y=y_location_text)
 
-    def draw_text(self, video_text: str, height_fraction: float) -> None:
+    def draw_text(self, video_text: str, height_fraction: float,
+                  interval: Optional[Tuple[float, float]] = None) -> None:
         """Draws text in the center of the video at a certain height fraction"""
         if not self.has_video:
             return

--- a/pypopquiz/backends/ffmpeg.py
+++ b/pypopquiz/backends/ffmpeg.py
@@ -56,16 +56,21 @@ class FFMpeg(ppq.backends.backend.Backend):
                                    second_stream.stream_a.filter("afifo"), v=0, a=1).node
             self.stream_a = joined[0]
 
-    def fade_in_and_out(self, duration_s: int, video_length_s: int) -> None:
+    def fade_in_and_out(self, duration_s: int, video_length_s: int, fade_in: bool = True,
+                        fade_out: bool = True) -> None:
         """Adds a fade-in and fade-out to/from black for the audio and video stream"""
         if self.has_video:
-            stream_v = self.stream_v.filter("fade", type="in", start_time=0, duration=duration_s)
-            self.stream_v = stream_v.filter("fade", type="out", start_time=video_length_s - duration_s,
-                                            duration=duration_s)
+            if fade_in:
+                self.stream_v = self.stream_v.filter("fade", type="in", start_time=0, duration=duration_s)
+            if fade_out:
+                self.stream_v = self.stream_v.filter("fade", type="out", start_time=video_length_s - duration_s,
+                                                     duration=duration_s)
         if self.has_audio:
-            stream_a = self.stream_a.filter("afade", type="in", start_time=0, duration=duration_s)
-            self.stream_a = stream_a.filter("afade", type="out", start_time=video_length_s - duration_s,
-                                            duration=duration_s)
+            if fade_in:
+                self.stream_a = self.stream_a.filter("afade", type="in", start_time=0, duration=duration_s)
+            if fade_out:
+                self.stream_a = self.stream_a.filter("afade", type="out", start_time=video_length_s - duration_s,
+                                                     duration=duration_s)
 
     def scale_video(self) -> None:
         """Scales the video and pads if necessary to the requested dimensions"""

--- a/pypopquiz/backends/moviepy.py
+++ b/pypopquiz/backends/moviepy.py
@@ -231,11 +231,13 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         self.clip = med.CompositeVideoClip(clips)
         self.clip = self.clip.set_duration(duration)
 
-    def draw_text(self, video_text: str, height_fraction: float) -> None:
+    def draw_text(self, video_text: str, height_fraction: float,
+                  interval: Optional[Tuple[float, float]] = None) -> None:
         """Draws text in the center of the video at a certain height fraction"""
         assert self.has_video
         duration_s = 0  # Don't care, uses interval
-        interval = (0, self.clip.duration)
+        if interval is None:
+            interval = (0, self.clip.duration)
         self.clip = Moviepy.draw_text_in_box_on_video(
             self.clip, video_text, duration_s, self.width, self.height, box_height=self.get_box_height(),
             move=False, top=False, on_box=False, center=True, vpos=height_fraction,
@@ -316,15 +318,6 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         video = med.CompositeVideoClip(clips)
         video.duration = duration
         return video
-
-    def overlay_fading_text(self, text: str, interval: Tuple[float, float]):
-        """Overlay fading text on the clip."""
-        assert self.has_video
-        duration_s = 0  # Don't care
-        self.clip = Moviepy.draw_text_in_box_on_video(
-            self.clip, text, duration_s, self.width, self.height, box_height=self.get_box_height(),
-            move=False, top=False, on_box=False, center=True, interval=interval, fontsize=self.get_font_size()
-        )
 
     def add_spacer(self, text: str, duration_s: float) -> None:
         """Add a text spacer to the start of the clip."""

--- a/pypopquiz/backends/moviepy.py
+++ b/pypopquiz/backends/moviepy.py
@@ -129,8 +129,8 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         else:
             self.clip = med.concatenate_audioclips([self.clip, self.clip])
 
-    def combine(self, other: 'Moviepy', other_first: bool = False,
-                crossfade_duration: float = 0) -> None:  # type: ignore
+    def combine(self, other: 'Moviepy', other_first: bool = False,  # type: ignore
+                crossfade_duration: float = 0) -> None:
         """Combines this video stream with another stream"""
         self.reader_refs += other.reader_refs
         clips = [other.clip, self.clip] if other_first else [self.clip, other.clip]

--- a/pypopquiz/backends/moviepy.py
+++ b/pypopquiz/backends/moviepy.py
@@ -85,12 +85,14 @@ class Moviepy(pypopquiz.backends.backend.Backend):
 
         elif has_audio:
             # Work only on audio from here on out
-            if audio_input_file:
+            if source_file.is_file():
+                # Extract audio stream from file (even if it is a video file)
                 self.clip = med.AudioFileClip(str(source_file))
                 self.reader_refs.append(self.clip)
             else:
-                self.clip = med.AudioClip(silence, duration=duration)
-                self.reader_refs.append(self.clip)
+                # A black clip w/o audio
+                duration = typing.cast(float, duration)
+                self.clip = self.create_color_clip((width, height), (0, 0, 0), duration)
         else:
             # Blank video
             assert duration is not None

--- a/pypopquiz/backends/moviepy.py
+++ b/pypopquiz/backends/moviepy.py
@@ -47,7 +47,7 @@ def tone_in_interval(clip: med.AudioClip, interval: Tuple[float, float], freq_hz
             return original
 
         # t is an array of timestamps:
-        selector = np.logical_and(interval[0] < t, interval[1] > t)
+        selector = np.logical_and(interval[0] < t, interval[1] > t)  # pylint: disable=assignment-from-no-return
         t_offset = t - interval[0]
         tone = np.array(np.sin(freq_hz * np.pi * t_offset))
 
@@ -85,6 +85,7 @@ class Moviepy(pypopquiz.backends.backend.Backend):
             else:
                 # Assume video otherwise
                 self.clip = med.VideoFileClip(str(source_file), audio=has_audio)
+                self.clip.set_fps(Moviepy.DEFAULT_FPS)
                 self.reader_refs.append(self.clip)
 
         elif has_audio:

--- a/pypopquiz/backends/moviepy.py
+++ b/pypopquiz/backends/moviepy.py
@@ -59,7 +59,7 @@ def tone_in_interval(clip: med.AudioClip, interval: Tuple[float, float], freq_hz
 
 class Moviepy(pypopquiz.backends.backend.Backend):
     """Moviepy backend."""
-    DEFAULT_FPS = 30
+    DEFAULT_FPS = 25
 
     def __init__(self, source_file: Path, has_video: bool, has_audio: bool,
                  width: int, height: int, duration: Optional[float] = None) -> None:
@@ -175,7 +175,6 @@ class Moviepy(pypopquiz.backends.backend.Backend):
                         fade_out: bool = True) -> None:
         """Adds a fade-in and fade-out to/from black for the audio and video stream"""
         if self.has_video:
-
             if fade_in:
                 self.clip = self.clip.fx(vfx.fadein, duration_s).\
                     fx(afx.audio_fadein, duration_s)
@@ -267,11 +266,12 @@ class Moviepy(pypopquiz.backends.backend.Backend):
             color_clip = med.ColorClip(size=(video_w, box_height), color=(0, 0, 0))
             color_clip = color_clip.set_fps(Moviepy.DEFAULT_FPS)  # pylint: disable=assignment-from-no-return
 
-            color_clip = color_clip.set_opacity(0.6)  # pylint: disable=assignment-from-no-return
+            color_clip = color_clip.set_opacity(0.5)  # pylint: disable=assignment-from-no-return
             color_clip = color_clip.set_position(pos=(0, y_location))
             clips.append(color_clip)
 
-        txt = med.TextClip(video_text, font='Arial', color='white', fontsize=fontsize)
+        stroke_color = 'black' if not on_box else None
+        txt = med.TextClip(video_text, font='Bauhaus-93', color='white', stroke_color=stroke_color, fontsize=fontsize)
 
         txt_y_location = (box_height - txt.h) // 2 + y_location
 
@@ -301,13 +301,8 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         clips.append(txt_mov)
 
         duration = video.duration
-        if isinstance(video, med.CompositeVideoClip):
-            # Add the new set of clips to the existing composition
-            clips = video.clips + clips
-            duration = video.duration
-        else:
-            # Add the input video as the first in the list
-            clips = [video] + clips
+        # Add the input video as the first in the list
+        clips = [video] + clips
 
         # Build a new composition out of the original clip and the text overlay.
         # video = med.CompositeVideoClip(clips, use_bgclip=interval is not None)

--- a/pypopquiz/backends/moviepy.py
+++ b/pypopquiz/backends/moviepy.py
@@ -70,6 +70,7 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         self.reader_refs = []  # type: List[moviepy.clip.Clip]
 
         audio_input_file = source_file.suffix in ('.mp3', '.wav',)
+        image_input_file = source_file.suffix in ('.png', '.jpg')
         if has_video:
             if audio_input_file:
                 # Create a black clip with the audio file pasted on top
@@ -78,6 +79,9 @@ class Moviepy(pypopquiz.backends.backend.Backend):
 
                 self.clip = self.create_color_clip((width, height), (0, 0, 0), audio.duration)
                 self.clip = self.clip.set_audio(audio)
+            elif image_input_file:
+                duration = typing.cast(float, duration)
+                self.clip = med.ImageClip(str(source_file), duration=duration)
             else:
                 # Assume video otherwise
                 self.clip = med.VideoFileClip(str(source_file), audio=has_audio)
@@ -111,6 +115,15 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         """Creates audio of a certain duration with no sound"""
         return cls(source_file=Path(''), has_video=False, has_audio=True, width=width, height=height,
                    duration=duration)
+
+    @classmethod
+    def create_single_image_stream(cls, input_image: Path, duration: int,
+                                   width: int, height: int) -> 'Moviepy':
+        """Creates a video of a certain duration with a single still image"""
+        stream = cls(Path(input_image), has_video=True, has_audio=False, width=width, height=height,
+                     duration=duration)
+        stream.scale_video()
+        return stream
 
     @staticmethod
     def create_color_clip(size: Tuple[int, int], color: Tuple[int, int, int], duration: float) -> med.ColorClip:
@@ -227,7 +240,8 @@ class Moviepy(pypopquiz.backends.backend.Backend):
         """Draws a semi-transparent box either at the top or bottom and writes text in it, optionally scrolling by"""
         assert self.has_video
         self.clip = Moviepy.draw_text_in_box_on_video(
-            self.clip, video_text, length, self.width, self.height, self.get_box_height(), move, top, fontsize=self.get_font_size()
+            self.clip, video_text, length, self.width, self.height, self.get_box_height(),
+            move, top, fontsize=self.get_font_size()
         )
 
     @staticmethod

--- a/pypopquiz/io.py
+++ b/pypopquiz/io.py
@@ -138,7 +138,7 @@ def verify_schema(input_data: Dict) -> None:
                                     "source": {"type": "number"},
                                     "interval": {"type": "array"},
                                     "reverse": {"type": "boolean"},
-                                    "answer_label_events": {"type": "string"}
+                                    "answer_label_events": {"type": ["string", "array"]}
                                 }
                             }
                         },
@@ -236,9 +236,9 @@ def verify_json_input(input_data: Dict) -> None:
                 if source_keys != {"duration"}:
                     raise ValueError("Missing source keys from image source {:s}".format(str(source)))
                 source["format"] = "mp4"  # default format
-        if len(question["answers"]) != len(question["answer_video"]):
-            raise ValueError("Expected {:d} answers, got {:d}".
-                             format(len(question["answer_video"]), len(question["answers"])))
+        # if len(question["answers"]) != len(question["answer_video"]):
+        #     raise ValueError("Expected {:d} answers, got {:d}".
+        #                      format(len(question["answer_video"]), len(question["answers"])))
         question_video_time = total_duration(question["question_video"])
         question_audio_time = total_duration(question["question_audio"])
         if question_video_time != question_audio_time:

--- a/pypopquiz/io.py
+++ b/pypopquiz/io.py
@@ -236,9 +236,7 @@ def verify_json_input(input_data: Dict) -> None:
                 if source_keys != {"duration"}:
                     raise ValueError("Missing source keys from image source {:s}".format(str(source)))
                 source["format"] = "mp4"  # default format
-        # if len(question["answers"]) != len(question["answer_video"]):
-        #     raise ValueError("Expected {:d} answers, got {:d}".
-        #                      format(len(question["answer_video"]), len(question["answers"])))
+
         question_video_time = total_duration(question["question_video"])
         question_audio_time = total_duration(question["question_audio"])
         if question_video_time != question_audio_time:

--- a/pypopquiz/io.py
+++ b/pypopquiz/io.py
@@ -258,7 +258,9 @@ def verify_json_input(input_data: Dict) -> None:
 def read_input(file_name: Path) -> Dict:
     """Reads and validates a popquiz input JSON file"""
     with file_name.open() as json_data:
-        input_data = json.load(json_data)
+        lines = json_data.read().splitlines()
+        lines = '\n'.join([line for line in lines if not line.strip().startswith('//')])
+        input_data = json.loads(lines)
         verify_schema(input_data)
         ppq.iovarsubs.substitute_variables(input_data)
         set_missing_intervals(input_data)

--- a/pypopquiz/io.py
+++ b/pypopquiz/io.py
@@ -240,10 +240,10 @@ def set_missing_intervals_from_duration(input_data: Dict) -> None:
                     source = question["sources"][source_index]
                     if "duration" not in source.keys():
                         raise ValueError("Missing interval for question {:d}'s '{:s}'".format(index, sub_type))
-                    else:
-                        sub_item["interval"] = get_missing_interval(source["duration"])
-                        log("Set duration for question {:d}'s '{:s}' to {:s}".
-                            format(index, sub_type, str(sub_item["interval"])))
+
+                    sub_item["interval"] = get_missing_interval(source["duration"])
+                    log("Set duration for question {:d}'s '{:s}' to {:s}".
+                        format(index, sub_type, str(sub_item["interval"])))
 
 
 def set_missing_media(input_data: Dict) -> None:

--- a/pypopquiz/io.py
+++ b/pypopquiz/io.py
@@ -201,6 +201,9 @@ def set_missing_intervals_from_av_pairs(input_data: Dict) -> None:
     for index, question in enumerate(input_data["questions"]):
         sources = question['sources']
         for sub_type in ("question_video", "answer_video"):
+            if sub_type not in question or other[sub_type] not in question:
+                continue
+
             for video, audio in zip(question[sub_type], question[other[sub_type]]):
                 audio_is_img = sources[video['source']]['source'] == 'image'
                 video_is_img = sources[video['source']]['source'] == 'image'

--- a/pypopquiz/popquiz.py
+++ b/pypopquiz/popquiz.py
@@ -49,10 +49,12 @@ def popquiz(input_file: Path, output_dir: Path, backend: str, downloader: str, w
     theme = '"{:s}"'.format(input_data["theme"])
     q_title = ppq.video.create_text_video(round_dir / ("{:02d}_questions_title.mp4".format(round_id)),
                                           ["Round {:02d}".format(round_id), theme],
-                                          title_text_duration_s, width=width, height=height, backend=backend)
+                                          title_text_duration_s, width=width, height=height,
+                                          use_cached_video_files=use_cached_video_files, backend=backend)
     a_title = ppq.video.create_text_video(round_dir / ("{:02d}_answers_title.mp4".format(round_id)),
                                           ["Answers for round {:02d}".format(round_id), theme],
-                                          title_text_duration_s, width=width, height=height, backend=backend)
+                                          title_text_duration_s, width=width, height=height,
+                                          use_cached_video_files=use_cached_video_files, backend=backend)
 
     q_videos, a_videos = [q_title], [a_title]
     for index, question in enumerate(input_data["questions"]):

--- a/pypopquiz/video.py
+++ b/pypopquiz/video.py
@@ -40,21 +40,27 @@ def filter_stream_video(stream: VideoBackend, kind: str, interval: Tuple[int, in
     if reverse:
         stream.reverse()
     stream.scale_video()
-    if kind == "answer" and answer_label_events is not None:
-        for event in answer_label_events:
-            evt_interval = event["interval"]
-            interval_sec = pypopquiz.io.get_interval_in_fractional_s(evt_interval)
-            offset_interval_sec = (interval_sec[0] - interval[0], interval_sec[1] - interval[0])
-            ppq.io.log('overlay_fading_text: {}'.format(event["answer"]))
-            stream.overlay_fading_text(event["answer"], interval=offset_interval_sec)
     if kind == "answer":
         # (up to the) first two answers are joined together with " - " and shown at the top
         answer_text = " - ".join(answer_texts[:2])
         stream.draw_text_in_box(answer_text, get_interval_length(interval), move=False, top=True,
                                 delay_in_sec=delay_answer_text_s)
         # Remainder is shown in the center of the video
-        for text_id, answer_text in enumerate(answer_texts[2:]):
+        text_id = 0
+        for answer_text in answer_texts[2:]:
             stream.draw_text(answer_text, 0.5 - 0.1 * len(answer_texts[2:]) + 0.2 * text_id)
+            text_id += 1
+
+        if answer_label_events is not None:
+            for event in answer_label_events:
+                interval_sec = pypopquiz.io.get_interval_in_fractional_s(event["interval"])
+                # Create interval relative to start of clip instead of source video
+                offset_interval_sec = (interval_sec[0] - interval[0], interval_sec[1] - interval[0])
+                ppq.io.log('overlay_fading_text: {}'.format(event["answer"]))
+                stream.draw_text(event["answer"],
+                                 0.5 - 0.1 * len(answer_label_events) + 0.2 * text_id,
+                                 interval=offset_interval_sec)
+                text_id += 1
 
     stream.fade_in_and_out(fade_amount_s, get_interval_length(interval))
     return stream

--- a/samples/round13.json
+++ b/samples/round13.json
@@ -15,7 +15,7 @@
         {"source": 0, "interval": ["0:15", "0:46"]}
       ],
       "question_audio": [
-        {"source": 0, "interval": ["0:15", "0:46"]}
+        {"source": 0}
       ],
       "answer_video": [
         {"source": 0, "interval": ["0:49", "1:03"]},
@@ -32,8 +32,8 @@
         }
       ],
       "answer_audio": [
-        {"source": 0, "interval": ["0:49", "1:03"]},
-        {"source": 1, "interval": ["1:05", "1:21"], "crossfade_duration": 3}
+        {"source": 0},
+        {"source": 1, "crossfade_duration": 3}
       ]
     } 
   ]

--- a/samples/round13.json
+++ b/samples/round13.json
@@ -1,0 +1,41 @@
+{
+  "round": 13,
+  "theme": "Cover test",
+  "questioned": ["artist", "title"],
+  "use_cached_video_files": false,
+  "questions": [
+    {
+      "repetitions": 1,
+      "answers": [{"artist": "Cover by Faith No More", "title": "Easy"}],
+      "sources": [
+        {"source": "youtube", "identifier": "vPzDTfIb0DU", "format": "mp4"},
+        {"source": "youtube", "identifier": "3DSVMDmzCcA", "format": "mp4"}
+      ],
+      "question_video": [
+        {"source": 0, "interval": ["0:15", "0:46"]}
+      ],
+      "question_audio": [
+        {"source": 0, "interval": ["0:15", "0:46"]}
+      ],
+      "answer_video": [
+        {"source": 0, "interval": ["0:49", "1:03"]},
+        {
+          "source": 1,
+          "interval": ["1:05", "1:21"],
+          "crossfade_duration": 3,
+          "answer_label_events": [
+            {
+              "interval": ["1:11", "1:18"],
+              "answer": "Original artist: Commodores"
+            }
+          ]
+        }
+      ],
+      "answer_audio": [
+        {"source": 0, "interval": ["0:49", "1:03"]},
+        {"source": 1, "interval": ["1:05", "1:21"], "crossfade_duration": 3}
+      ]
+    } 
+  ]
+}
+


### PR DESCRIPTION
* Crossfade feature for moviepy backend. Set `crossfade_duration` on the clip that should be faded into, e.g. the second, clip in a list. See samples/round13.json for an example.
* Moviepy backend now supports image clips.
* Automatically complete missing json duration and interval fields where possible.
* Title slides / videos are now also cached.
* Example question now also has spacer.
* Improved moviepy text style.
* Changed travis config to test on xenial: mostly because trusty doesn't have an ffmpeg package, which makes installing it for testing needlessly complicated.
* Fixed bug where adding text on top of a composite video would remove the fade effect from the composite.

This merge request absorbed a little more changes than I originally intended. I hope it is still clear.